### PR TITLE
Doc 4217 alphabetize k8s

### DIFF
--- a/get-started/requirements.adoc
+++ b/get-started/requirements.adoc
@@ -148,23 +148,23 @@ Astra Control has the following application management requirements:
 |ClusterRoleBinding
 |ConfigMap
 
+|CronJob
 |CustomResourceDefinition
 |CustomResource
-|CronJob
 
 |DaemonSet
-|HorizontalPodAutoscaler
-|Ingress
-
 |DeploymentConfig
-|MutatingWebhook
-|PersistentVolumeClaim
+|HorizontalPodAutoscaler
 
+|Ingress
+|MutatingWebhook
+|NetworkPolicy
+
+|PersistentVolumeClaim
 |Pod
 |PodDisruptionBudget
-|PodTemplate
 
-|NetworkPolicy
+|PodTemplate
 |ReplicaSet
 |Role
 


### PR DESCRIPTION
Apps that use Kubernetes resources are now in alphabetical order in the table.